### PR TITLE
feat(package): add default export condition to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
Add 'default' condition to exports field to improve compatibility with modern bundlers like esbuild that rely on default conditions when other specific conditions don't match.